### PR TITLE
Fix value conversion for floating point numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -18,9 +18,9 @@ module.exports = (options = {}) => {
                     const regExType = new RegExp(/(convert-r?em|px)/, 'ig');
                     const unit = regExType.exec(el)[0].toString().replace(/^convert-/, '');
                     const measureType = options.unit ? options.unit : unit !== 'px' ? unit : 'rem';
-                    return convertedVal = regExVal.exec(el) / base + measureType;
+                    return regExVal.exec(el) / base + measureType;
                 });
-            }
+            };
 
             const replaceItem = (item, convertedValues, matches) => {
                 let revisedParam = item;
@@ -28,14 +28,14 @@ module.exports = (options = {}) => {
                     revisedParam = revisedParam.replace(matches[i], el);
                 });
                 return revisedParam
-            }
+            };
 
             css.walkRules((rule) => {
                 const ruleParent = rule.parent;
 
                 if (ruleParent.type === "atrule" && ruleParent.name === "media" && mediaQueries) {
                     const matches = findMatches(ruleParent.params) || false;
-                    const convertedVal = matches ? convertedVal = convertValues(matches) : false;
+                    const convertedVal = matches ? convertValues(matches) : false;
 
                     if (convertedVal) {
                         rule.parent.params = replaceItem(rule.parent.params, convertedVal, matches);

--- a/index.js
+++ b/index.js
@@ -1,56 +1,53 @@
-var postcss = require('postcss');
+const postcss = require('postcss');
 
-module.exports = function (options) {
-    options = options || {};
+module.exports = (options = {}) => {
     return {
         postcssPlugin: 'postcss-pixels-to-rem',
-        Once: function (css) {
-            var base = options.base ? options.base : 16,
-                mediaQueries = options.mediaQueries === undefined ? true: options.mediaQueries,
-                exclude = options.exclude || [];
+        Once: (css) => {
+            const base = options.base ? options.base : 16;
+            const mediaQueries = options.mediaQueries === undefined ? true: options.mediaQueries;
+            const exclude = options.exclude || [];
 
-            function findMatches (el) {
-                return el.match(/(em\([\d.]+\)|rem\([\d.]+\)|[\d.]+px)/ig, "");
+            const findMatches = (el) => {
+                return el.match(/(convert-r?em\([\d.]+\)|[\d.]+px)/ig, '');
             };
 
-            function convertValues(matches) {
-                var revised = matches.map(function(el, i) {
-                    var regExVal = new RegExp(/[\d.]+/, 'g'),
-                        regExType = new RegExp(/(^em|rem|px)/, 'ig'),
-                        unit = regExType.exec(el)[0].toString();
-                    var measureType = options.unit ? options.unit : unit !== 'px' ? unit: 'rem';
+            const convertValues = (matches) => {
+                return matches.map((el, i) => {
+                    const regExVal = new RegExp(/[\d.]+/, 'g');
+                    const regExType = new RegExp(/(convert-r?em|px)/, 'ig');
+                    const unit = regExType.exec(el)[0].toString().replace(/^convert-/, '');
+                    const measureType = options.unit ? options.unit : unit !== 'px' ? unit : 'rem';
                     return convertedVal = regExVal.exec(el) / base + measureType;
                 });
-                return revised
             }
 
-            function replaceItem(item, convertedValues, matches) {
-                var revisedParam = item;
-                convertedValues.map(function(el, i) {
+            const replaceItem = (item, convertedValues, matches) => {
+                let revisedParam = item;
+                convertedValues.map((el, i) => {
                     revisedParam = revisedParam.replace(matches[i], el);
                 });
                 return revisedParam
             }
 
-            css.walkRules(function (rule) {
-                var ruleParent = rule.parent;
+            css.walkRules((rule) => {
+                const ruleParent = rule.parent;
 
                 if (ruleParent.type === "atrule" && ruleParent.name === "media" && mediaQueries) {
-                    var matches = findMatches(ruleParent.params) || false,
-                        convertedVal = matches? convertedVal = convertValues(matches): false;
+                    const matches = findMatches(ruleParent.params) || false;
+                    const convertedVal = matches ? convertedVal = convertValues(matches) : false;
 
                     if (convertedVal) {
                         rule.parent.params = replaceItem(rule.parent.params, convertedVal, matches);
                     }
                 }
-                rule.walkDecls(function (decl, i) {
-                    var excludedTest = exclude.some(function(el, i){
-                        return decl.prop === el;
-                    });
-                    var matches = findMatches(decl.value);
+
+                rule.walkDecls((decl, i) => {
+                    const excludedTest = exclude.some((el, i) => decl.prop === el);
+                    const matches = findMatches(decl.value);
+
                     if (matches && !excludedTest) {
-                        var convertedValues = convertValues(matches);
-                        decl.value = replaceItem(decl.value, convertedValues, matches);
+                        decl.value = replaceItem(decl.value, convertValues(matches), matches);
                     }
                 });
             });

--- a/index.js
+++ b/index.js
@@ -8,12 +8,12 @@ module.exports = postcss.plugin('postcss-pixels-to-rem', function pixelstorem(op
           exclude = options.exclude || [];
 
       function findMatches (el) {
-        return el.match(/(em\(\d+\)|rem\(\d+\)|\d+px)/ig, "");
+        return el.match(/(em\([\d.]+\)|rem\([\d.]+\)|[\d.]+px)/ig, "");
       };
 
       function convertValues(matches) {
         var revised = matches.map(function(el, i) {
-          var regExVal = new RegExp(/\d+/, 'g'),
+          var regExVal = new RegExp(/[\d.]+/, 'g'),
               regExType = new RegExp(/(^em|rem|px)/, 'ig'),
               unit = regExType.exec(el)[0].toString();
           var measureType = options.unit ? options.unit : unit !== 'px' ? unit: 'rem';

--- a/index.js
+++ b/index.js
@@ -1,56 +1,62 @@
 var postcss = require('postcss');
 
-module.exports = postcss.plugin('postcss-pixels-to-rem', function pixelstorem(options) {
-  return function (css) {
-      options = options || {};
-      var base = options.base ? options.base : 16,
-          mediaQueries = options.mediaQueries === undefined ? true: options.mediaQueries,
-          exclude = options.exclude || [];
+module.exports = function (options) {
+    options = options || {};
+    return {
+        postcssPlugin: 'postcss-pixels-to-rem',
+        Once: function (css) {
+            var base = options.base ? options.base : 16,
+                mediaQueries = options.mediaQueries === undefined ? true: options.mediaQueries,
+                exclude = options.exclude || [];
 
-      function findMatches (el) {
-        return el.match(/(em\([\d.]+\)|rem\([\d.]+\)|[\d.]+px)/ig, "");
-      };
+            function findMatches (el) {
+                return el.match(/(em\([\d.]+\)|rem\([\d.]+\)|[\d.]+px)/ig, "");
+            };
 
-      function convertValues(matches) {
-        var revised = matches.map(function(el, i) {
-          var regExVal = new RegExp(/[\d.]+/, 'g'),
-              regExType = new RegExp(/(^em|rem|px)/, 'ig'),
-              unit = regExType.exec(el)[0].toString();
-          var measureType = options.unit ? options.unit : unit !== 'px' ? unit: 'rem';
-          return convertedVal = regExVal.exec(el) / base + measureType;
-        });
-        return revised
-      }
+            function convertValues(matches) {
+                var revised = matches.map(function(el, i) {
+                    var regExVal = new RegExp(/[\d.]+/, 'g'),
+                        regExType = new RegExp(/(^em|rem|px)/, 'ig'),
+                        unit = regExType.exec(el)[0].toString();
+                    var measureType = options.unit ? options.unit : unit !== 'px' ? unit: 'rem';
+                    return convertedVal = regExVal.exec(el) / base + measureType;
+                });
+                return revised
+            }
 
-    function replaceItem(item, convertedValues, matches) {
-      var revisedParam = item;
-      convertedValues.map(function(el, i) {
-        revisedParam = revisedParam.replace(matches[i], el);
-      });
-      return revisedParam
-    }
+            function replaceItem(item, convertedValues, matches) {
+                var revisedParam = item;
+                convertedValues.map(function(el, i) {
+                    revisedParam = revisedParam.replace(matches[i], el);
+                });
+                return revisedParam
+            }
 
-    css.walkRules(function (rule) {
-      var ruleParent = rule.parent;
+            css.walkRules(function (rule) {
+                var ruleParent = rule.parent;
 
-      if (ruleParent.type === "atrule" && ruleParent.name === "media" && mediaQueries) {
-        var matches = findMatches(ruleParent.params) || false,
-            convertedVal = matches? convertedVal = convertValues(matches): false;
+                if (ruleParent.type === "atrule" && ruleParent.name === "media" && mediaQueries) {
+                    var matches = findMatches(ruleParent.params) || false,
+                        convertedVal = matches? convertedVal = convertValues(matches): false;
 
-        if (convertedVal) {
-          rule.parent.params = replaceItem(rule.parent.params, convertedVal, matches);
+                    if (convertedVal) {
+                        rule.parent.params = replaceItem(rule.parent.params, convertedVal, matches);
+                    }
+                }
+                rule.walkDecls(function (decl, i) {
+                    var excludedTest = exclude.some(function(el, i){
+                        return decl.prop === el;
+                    });
+                    var matches = findMatches(decl.value);
+                    if (matches && !excludedTest) {
+                        var convertedValues = convertValues(matches);
+                        decl.value = replaceItem(decl.value, convertedValues, matches);
+                    }
+                });
+            });
         }
-      }
-      rule.walkDecls(function (decl, i) {
-        var excludedTest = exclude.some(function(el, i){
-            return decl.prop === el;
-        });
-        var matches = findMatches(decl.value);
-        if (matches && !excludedTest) {
-          var convertedValues = convertValues(matches);
-          decl.value = replaceItem(decl.value, convertedValues, matches);
-        }
-      });
-    });
-  }
-});
+    };
+};
+
+module.exports.postcss = true;
+

--- a/index.test.js
+++ b/index.test.js
@@ -1,0 +1,40 @@
+const postcss = require('postcss');
+const { equal } = require('node:assert');
+const { test } = require('node:test');
+
+const plugin = require('./');
+
+async function run(input, output, opts = {}) {
+  let result = await postcss([plugin(opts)]).process(input, { from: undefined })
+  equal(result.css, output)
+  equal(result.warnings().length, 0)
+}
+
+test('it converts convert-rem to the right syntax', async () => {
+    await run(`.foo { font-size: convert-rem(10); }`, `.foo { font-size: 0.625rem; }`);
+});
+
+test('it converts convert-em to the right syntax', async () => {
+    await run(`.foo { font-size: convert-em(10); }`, `.foo { font-size: 0.625em; }`);
+});
+
+test('it ignores regular rem function calls', async () => {
+    await run(`.foo { font-size: rem(10); }`, `.foo { font-size: rem(10); }`);
+});
+
+test('it ignores regular rems', async () => {
+    await run(`.foo { font-size: 10rem; }`, `.foo { font-size: 10rem; }`);
+});
+
+test('it converts px to the right unit', async () => {
+    await run(`.foo { font-size: 10px; }`, `.foo { font-size: 0.625rem; }`);
+});
+
+test('a base can be specified', async () => {
+    await run(`.foo { font-size: 10px; }`, `.foo { font-size: 1rem; }`, { base: 10 });
+});
+
+test('css properties can be excluded', async () => {
+    await run(`.foo { font-size: 10px; }`, `.foo { font-size: 10px; }`, { exclude: ['font-size'] });
+});
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,16 @@
   "description": "Converts pixel measurements into rems or ems. Works with the same pixels to rem or pixels to em syntax as Bourbon, so no rewrite of CSS source code is required.",
   "main": "index.js",
   "scripts": {
-    "test": "pixelstorem"
+    "test": "node --test index.test.js"
+  },
+  "engine": {
+    "node": ">=18.0.0"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.0"
+  },
+  "devDependencies": {
+    "postcss": "^8.0.0"
   },
   "keywords": [
     "pixels",


### PR DESCRIPTION
As it currently stands the plugin doesn't handle floating point numbers correctly, so the following produces incorrect output:

```css
font-size: 24.5px;
/* Output: font-size: 24.0.3125rem; */
```

This PR fixes this so that the above correctly outputs `1.53125rem`